### PR TITLE
setTimeとsetTimeSecondsの統一

### DIFF
--- a/src/popup.test.ts
+++ b/src/popup.test.ts
@@ -71,7 +71,7 @@ describe('PomodoroTimer', () => {
       timer = new PomodoroTimer()
       await vi.waitFor(() => timer.getTimeLeft() === 25 * 60, { timeout: 1000 })
       
-      await timer.setTime(25)
+      await timer.setTimeSeconds(25 * 60)
       expect(timer.getTimeLeft()).toBe(25 * 60)
     })
 
@@ -79,7 +79,7 @@ describe('PomodoroTimer', () => {
       timer = new PomodoroTimer()
       await vi.waitFor(() => timer.getTimeLeft() === 25 * 60, { timeout: 1000 })
       
-      await timer.setTime(15)
+      await timer.setTimeSeconds(15 * 60)
       expect(timer.getTimeLeft()).toBe(15 * 60)
     })
 
@@ -87,7 +87,7 @@ describe('PomodoroTimer', () => {
       timer = new PomodoroTimer()
       await vi.waitFor(() => timer.getTimeLeft() === 25 * 60, { timeout: 1000 })
       
-      await timer.setTime(5)
+      await timer.setTimeSeconds(5 * 60)
       expect(timer.getTimeLeft()).toBe(5 * 60)
     })
 
@@ -136,7 +136,7 @@ describe('PomodoroTimer', () => {
       
       await timer.start()
       const initialTime = timer.getTimeLeft()
-      await timer.setTime(10)
+      await timer.setTimeSeconds(10 * 60)
       expect(timer.getTimeLeft()).toBe(initialTime)
     })
 

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -120,9 +120,9 @@ export class PomodoroTimer {
     this.startBtn.addEventListener('click', () => this.start());
     this.pauseBtn.addEventListener('click', () => this.pause());
     
-    this.preset25.addEventListener('click', () => this.setTime(25));
-    this.preset15.addEventListener('click', () => this.setTime(15));
-    this.preset5.addEventListener('click', () => this.setTime(5));
+    this.preset25.addEventListener('click', () => this.setTimeSeconds(25 * 60));
+    this.preset15.addEventListener('click', () => this.setTimeSeconds(15 * 60));
+    this.preset5.addEventListener('click', () => this.setTimeSeconds(5 * 60));
     this.preset1sec.addEventListener('click', () => this.setTimeSeconds(1));
   }
   
@@ -149,14 +149,6 @@ export class PomodoroTimer {
     }
   }
   
-  public async setTime(minutes: number): Promise<void> {
-    if (!this.state.isRunning) {
-      this.state.timeLeft = minutes * 60;
-      this.updateDisplay();
-      await this.saveState();
-    }
-  }
-  
   public async setTimeSeconds(seconds: number): Promise<void> {
     if (!this.state.isRunning) {
       this.state.timeLeft = seconds;
@@ -175,7 +167,7 @@ export class PomodoroTimer {
   
   private async complete(): Promise<void> {
     await this.pause();
-    await this.setTime(PomodoroTimer.DEFAULT_MINUTES);
+    await this.setTimeSeconds(PomodoroTimer.DEFAULT_MINUTES * 60);
   }
   
   private updateDisplay(): void {


### PR DESCRIPTION
⏺ 完了しました！setTimeとsetTimeSecondsの統
  一が成功しました：

  変更内容

  1. setTime(minutes)メソッドを削除
  2. setTimeSeconds(seconds)に統一
  3. イベントリスナー更新:
  プリセットボタンで秒数を直接指定
    - 25分 → 25 * 60秒
    - 15分 → 15 * 60秒
    - 5分 → 5 * 60秒
  4. テスト修正:
  全テストでsetTimeSecondsを使用

  メリット

  - APIの簡素化:
  1つのメソッドで時間設定を統一
  - 保守性向上: 重複メソッドの削除
  - 一貫性: 内部では全て秒単位で処理

  テストとビルドも問題なく通っており、リフ
  ァクタリングが完了しました。