### PR TITLE
タイマーが稼働中なのかどうかと、作業中なのか休憩中なのかが、ポップアップを開かないとわからない

### DIFF
--- a/src/background.test.ts
+++ b/src/background.test.ts
@@ -33,6 +33,9 @@ const mockChrome = {
   },
   action: {
     openPopup: vi.fn(),
+    setBadgeText: vi.fn(),
+    setBadgeBackgroundColor: vi.fn(),
+    setTitle: vi.fn(),
   },
 };
 
@@ -461,6 +464,57 @@ describe('BackgroundTimer', () => {
 
       // 通知ページが開かれることを確認
       expect(mockChrome.tabs.create).toHaveBeenCalled();
+    });
+  });
+
+  describe('action badge', () => {
+    let messageHandler: (message: any, sender: any, sendResponse: any) => any;
+
+    beforeEach(async () => {
+      backgroundTimer = new BackgroundTimer();
+      await new Promise(resolve => setTimeout(resolve, 10));
+      messageHandler = mockChrome.runtime.onMessage.addListener.mock.calls[0][0];
+      vi.clearAllMocks();
+    });
+
+    it('should show remaining minutes with the work color while running', async () => {
+      await messageHandler({ type: 'START_TIMER' }, {}, () => {});
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockChrome.action.setBadgeText).toHaveBeenCalledWith({ text: '25' });
+      expect(mockChrome.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#d32f2f' });
+    });
+
+    it('should use the break color after jumping to a break session', async () => {
+      // position 2 は短い休憩
+      await messageHandler({ type: 'JUMP_TO_POSITION', position: 2 }, {}, () => {});
+      await new Promise(resolve => setTimeout(resolve, 10));
+      vi.clearAllMocks();
+
+      await messageHandler({ type: 'START_TIMER' }, {}, () => {});
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockChrome.action.setBadgeText).toHaveBeenCalledWith({ text: '5' });
+      expect(mockChrome.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#388e3c' });
+    });
+
+    it('should show the paused indicator when paused', async () => {
+      await messageHandler({ type: 'START_TIMER' }, {}, () => {});
+      await new Promise(resolve => setTimeout(resolve, 10));
+      vi.clearAllMocks();
+
+      await messageHandler({ type: 'PAUSE_TIMER' }, {}, () => {});
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockChrome.action.setBadgeText).toHaveBeenCalledWith({ text: '||' });
+      expect(mockChrome.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: '#9e9e9e' });
+    });
+
+    it('should clear the badge when reset', async () => {
+      await messageHandler({ type: 'RESET_TIMER' }, {}, () => {});
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      expect(mockChrome.action.setBadgeText).toHaveBeenCalledWith({ text: '' });
     });
   });
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -17,6 +17,12 @@ interface TimerState {
 }
 
 export class BackgroundTimer {
+  private static readonly sessionConfig: Record<'work' | 'shortBreak' | 'longBreak', { color: string; text: string }> = {
+    work: { color: '#d32f2f', text: '作業中' },
+    shortBreak: { color: '#388e3c', text: '短い休憩' },
+    longBreak: { color: '#1976d2', text: '長い休憩' }
+  };
+
   private readonly alarmName = 'pomodoroTimer';
   private readonly syncAlarmName = 'pomodoroSync';
   private readonly notificationPageUrl = chrome.runtime.getURL('notification.html');
@@ -346,38 +352,40 @@ export class BackgroundTimer {
 
   private async updateActionBadge(): Promise<void> {
     try {
-      if (this.state.isRunning) {
-        const minutes = Math.ceil(this.calculateCurrentTimeLeft() / 60);
-        await chrome.action.setBadgeText({ text: minutes >= 1 ? String(minutes) : '<1' });
-        await chrome.action.setBadgeBackgroundColor({ color: this.getBadgeColor(this.state.sessionType) });
-        await chrome.action.setTitle({ title: `pomobop - ${this.getSessionTypeText(this.state.sessionType)}` });
-      } else if (this.state.pausedAt !== null) {
-        await chrome.action.setBadgeText({ text: '||' });
-        await chrome.action.setBadgeBackgroundColor({ color: '#9e9e9e' });
-        await chrome.action.setTitle({ title: `pomobop - 一時停止中（${this.getSessionTypeText(this.state.sessionType)}）` });
-      } else {
-        await chrome.action.setBadgeText({ text: '' });
-        await chrome.action.setTitle({ title: 'pomobop' });
+      const { text, color, title } = this.getBadgeAppearance();
+
+      const updates: Promise<void>[] = [
+        chrome.action.setBadgeText({ text }),
+        chrome.action.setTitle({ title })
+      ];
+      if (color !== null) {
+        updates.push(chrome.action.setBadgeBackgroundColor({ color }));
       }
+      await Promise.all(updates);
     } catch (error) {
       console.error('Failed to update action badge:', error);
     }
   }
 
-  private getBadgeColor(sessionType: 'work' | 'shortBreak' | 'longBreak'): string {
-    switch (sessionType) {
-      case 'work': return '#d32f2f';
-      case 'shortBreak': return '#388e3c';
-      case 'longBreak': return '#1976d2';
-    }
-  }
+  private getBadgeAppearance(): { text: string; color: string | null; title: string } {
+    const config = BackgroundTimer.sessionConfig[this.state.sessionType];
 
-  private getSessionTypeText(sessionType: 'work' | 'shortBreak' | 'longBreak'): string {
-    switch (sessionType) {
-      case 'work': return '作業中';
-      case 'shortBreak': return '短い休憩';
-      case 'longBreak': return '長い休憩';
+    if (this.state.isRunning) {
+      const minutes = Math.ceil(this.calculateCurrentTimeLeft() / 60);
+      return {
+        text: minutes >= 1 ? String(minutes) : '<1',
+        color: config.color,
+        title: `pomobop - ${config.text}`
+      };
     }
+    if (this.state.pausedAt !== null) {
+      return {
+        text: '||',
+        color: '#9e9e9e',
+        title: `pomobop - 一時停止中（${config.text}）`
+      };
+    }
+    return { text: '', color: null, title: 'pomobop' };
   }
 
   private async broadcastState(): Promise<void> {

--- a/src/background.ts
+++ b/src/background.ts
@@ -322,6 +322,9 @@ export class BackgroundTimer {
     } catch (error) {
       // ポップアップが閉じている場合は無視
     }
+
+    // 残り分数のバッジ表示を最新に保つ
+    await this.updateActionBadge();
   }
 
   private async saveAndBroadcastState(): Promise<void> {
@@ -336,8 +339,45 @@ export class BackgroundTimer {
       pausedAt: this.state.pausedAt,
       pausedDuration: this.state.pausedDuration || 0
     };
-    
+
     await chrome.storage.local.set({ pomodoroState: stateToSave });
+    await this.updateActionBadge();
+  }
+
+  private async updateActionBadge(): Promise<void> {
+    try {
+      if (this.state.isRunning) {
+        const minutes = Math.ceil(this.calculateCurrentTimeLeft() / 60);
+        await chrome.action.setBadgeText({ text: minutes >= 1 ? String(minutes) : '<1' });
+        await chrome.action.setBadgeBackgroundColor({ color: this.getBadgeColor(this.state.sessionType) });
+        await chrome.action.setTitle({ title: `pomobop - ${this.getSessionTypeText(this.state.sessionType)}` });
+      } else if (this.state.pausedAt !== null) {
+        await chrome.action.setBadgeText({ text: '||' });
+        await chrome.action.setBadgeBackgroundColor({ color: '#9e9e9e' });
+        await chrome.action.setTitle({ title: `pomobop - 一時停止中（${this.getSessionTypeText(this.state.sessionType)}）` });
+      } else {
+        await chrome.action.setBadgeText({ text: '' });
+        await chrome.action.setTitle({ title: 'pomobop' });
+      }
+    } catch (error) {
+      console.error('Failed to update action badge:', error);
+    }
+  }
+
+  private getBadgeColor(sessionType: 'work' | 'shortBreak' | 'longBreak'): string {
+    switch (sessionType) {
+      case 'work': return '#d32f2f';
+      case 'shortBreak': return '#388e3c';
+      case 'longBreak': return '#1976d2';
+    }
+  }
+
+  private getSessionTypeText(sessionType: 'work' | 'shortBreak' | 'longBreak'): string {
+    switch (sessionType) {
+      case 'work': return '作業中';
+      case 'shortBreak': return '短い休憩';
+      case 'longBreak': return '長い休憩';
+    }
   }
 
   private async broadcastState(): Promise<void> {
@@ -378,6 +418,8 @@ export class BackgroundTimer {
           await this.handleTimerComplete();
         }
       }
+
+      await this.updateActionBadge();
     }
   }
 }


### PR DESCRIPTION
拡張アイコン（chrome.action）のバッジでタイマー状態を可視化し、ポップアップを開かなくても稼働中かどうか・作業中か休憩中かが分かるようにした。

## 変更内容
- 稼働中: 残り分数を表示し、セッション種別ごとの背景色（作業=赤 / 短い休憩=緑 / 長い休憩=青）
- 一時停止中: `||` + グレー
- 未開始/リセット時: バッジを消す
- ツールチップ（setTitle）も状態に合わせて更新

## 動作確認手順
1. `npm run build` でビルドし、拡張を読み込む
2. タイマーを開始 → アイコンに残り分数と作業色（赤）が出る
3. 休憩セッションにジャンプして開始 → 緑/青になる
4. 一時停止 → `||` とグレーになる
5. リセット → バッジが消える

## 検証済み
- `npm run build`（tsc）が通る
- `npm test` が全57テストパス

Closes #40